### PR TITLE
Fixed Plugin class import

### DIFF
--- a/src/ResizableHeight.js
+++ b/src/ResizableHeight.js
@@ -1,6 +1,6 @@
 //Pikulin.PW ResizableHeight Plugin – https://github.com/pikulinpw/ckeditor5-resizableheight
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import { Plugin } from 'ckeditor5';
 
 export default class ResizableHeight extends Plugin {
     init() {


### PR DESCRIPTION
This just fixes the import for the Plugin class in ckeditor.
Reference: https://ckeditor.com/docs/ckeditor5/latest/framework/tutorials/creating-simple-plugin-timestamp.html#creating-a-plugin